### PR TITLE
BUGFIX: Correctly handle removing the form persistence finisher

### DIFF
--- a/Classes/SignalSlot/NodeSignalInterceptor.php
+++ b/Classes/SignalSlot/NodeSignalInterceptor.php
@@ -43,7 +43,12 @@ class NodeSignalInterceptor
 
         $formIdentifier = $form->getProperty('identifier');
 
-        if (trim($node->getProperty('scheduledExportRecipient')) === '' || trim($node->getProperty('exportDefinition')) === '') {
+        if ($node->isRemoved()) {
+            $scheduledExportService->removeScheduledExportDefinitionIfExists($formIdentifier);
+            return;
+        }
+
+        if (trim((string)$node->getProperty('scheduledExportRecipient')) === '' || trim((string)$node->getProperty('exportDefinition')) === '') {
             $scheduledExportService->removeScheduledExportDefinitionIfExists($formIdentifier);
             return;
         }


### PR DESCRIPTION
When removing a form persistence finisher without data configured. The publishing process crashes because of a trim on null.