### PR TITLE
BUGFIX: add default value for dimension hash

### DIFF
--- a/Classes/Domain/Model/FormData.php
+++ b/Classes/Domain/Model/FormData.php
@@ -60,7 +60,7 @@ class FormData
      * @var string
      * @ORM\Column(length=32)
      */
-    protected $dimensionsHash;
+    protected $dimensionsHash = '';
 
     /**
      * @ORM\Column(type="flow_json_array")


### PR DESCRIPTION
add default value for dimension hash to prevent dbal exception, when site hash no dimension config