### PR TITLE
BUGFIX: adjust check in getCurrentBackendUser to prevent exception in cli

### DIFF
--- a/Classes/Domain/ScheduledExport/ScheduledExportService.php
+++ b/Classes/Domain/ScheduledExport/ScheduledExportService.php
@@ -67,6 +67,6 @@ class ScheduledExportService
 
     protected function getCurrentBackendUser(): string
     {
-        return $this->securityContext->getAccount() instanceof Account ? $this->securityContext->getAccount()->getAccountIdentifier() : 'unknown';
+        return $this->securityContext->canBeInitialized() && $this->securityContext->getAccount() instanceof Account ? $this->securityContext->getAccount()->getAccountIdentifier() : 'unknown';
     }
 }


### PR DESCRIPTION
When calling flow cammand like `./flow workspace:publish` which triggers the `NodeSignalInterceptor` `getAccount` in `getCurrentBackendUser` throws an exception becaous in the cli context there is noch backend user. By adding `$this->securityContext->canBeInitialized()` this exception is prevented.