### PR TITLE
FEATURE: generate version hash from renderables id

### DIFF
--- a/Classes/Finishers/SaveFormDataFinisher.php
+++ b/Classes/Finishers/SaveFormDataFinisher.php
@@ -52,11 +52,18 @@ class SaveFormDataFinisher extends AbstractFinisher
         $fieldValues = $this->finisherContext->getFormValues();
 
         $formFieldsData = [];
+        $formFieldIdentifiers = [];
         $fieldIdentifiersString = '';
 
         $excludedFormTypes = array_keys(array_filter($this->excludedFormTypes));
 
-        foreach ($fieldValues as $identifier => $fieldValue) {
+        foreach ($formRuntime->getPages() as $page) {
+            foreach ( $page->getElementsRecursively() as $renderable) {
+                $formFieldIdentifiers[] = $renderable->getIdentifier();
+            }
+        }
+
+        foreach ($formFieldIdentifiers as $identifier) {
 
             if (!$formRuntime->getFormDefinition()->getElementByIdentifier($identifier) instanceof AbstractFormElement) {
                 continue;
@@ -66,7 +73,7 @@ class SaveFormDataFinisher extends AbstractFinisher
                 continue;
             }
 
-            $formFieldsData[$identifier] = $fieldValue;
+            $formFieldsData[$identifier] = $fieldValues[$identifier] ?? '';
             $fieldIdentifiersString .= $identifier;
         }
 

--- a/Classes/Finishers/SaveFormDataFinisher.php
+++ b/Classes/Finishers/SaveFormDataFinisher.php
@@ -58,7 +58,7 @@ class SaveFormDataFinisher extends AbstractFinisher
         $excludedFormTypes = array_keys(array_filter($this->excludedFormTypes));
 
         foreach ($formRuntime->getPages() as $page) {
-            foreach ( $page->getElementsRecursively() as $renderable) {
+            foreach ($page->getElementsRecursively() as $renderable) {
                 $formFieldIdentifiers[] = $renderable->getIdentifier();
             }
         }


### PR DESCRIPTION
With this feature the version hash is generated from the renderables identifier and not from the identifiers of the submitted fields. This prevents different version hashs for the same form, if several optional checkboxes are part of the form.