### PR TITLE
feat: Allow manual override of formIdentifier via Fusion

### DIFF
--- a/Classes/Finishers/SaveFormDataFinisher.php
+++ b/Classes/Finishers/SaveFormDataFinisher.php
@@ -79,7 +79,7 @@ class SaveFormDataFinisher extends AbstractFinisher
 
         $formData = new FormData();
 
-        $formData->setFormIdentifier($formRuntime->getIdentifier());
+        $formData->setFormIdentifier($this->options['formIdentifier'] ?? $formRuntime->getIdentifier());
         $formData->setHash(sha1($fieldIdentifiersString));
         $formData->setFormData($formFieldsData);
         $formData->setDate(new \DateTime());


### PR DESCRIPTION
This allows to override the Form Identifier with Fusion. Which is helpful to "group" submits from different forms under the same identifier.